### PR TITLE
Return bucket name instead of bucket arn

### DIFF
--- a/aws/output.tf
+++ b/aws/output.tf
@@ -11,5 +11,5 @@ output "region" {
 }
 
 output "bucket_name" {
-  value = aws_s3_bucket.state_bucket.arn
+  value = var.state_bucket_name
 }


### PR DESCRIPTION
We are returning bucket arn and want to make the process as copy-paste as possible so returning bucket name instead