### PR TITLE
Feature: using stricter role for assume role

### DIFF
--- a/aws/iam.tf
+++ b/aws/iam.tf
@@ -8,7 +8,7 @@ resource "aws_iam_role" "remote_state_access_role" {
         Action    = "sts:AssumeRole"
         Effect    = "Allow"
         Principal = {
-          AWS = "arn:aws:iam::${var.env0_aws_account_id}:root"
+          AWS = var.env0_aws_role_name
         }
         Condition = {
           StringEquals = {

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -10,7 +10,7 @@ variable "region" {
   description = "The aws account region to deploy the state bucket in"
 }
 
-variable "env0_aws_account_id" {
-  description = "The env0 account id which is assuming the role"
-  default     = "913128560467"
+variable "env0_aws_role_name" {
+  description = "The env0 role arn which is assuming the role"
+  default     = "arn:aws:iam::913128560467:role/remote-backend-prod"
 }


### PR DESCRIPTION
### description:
JFrog asked for a specific role to be used, not some root/admin user

### solution:
- allow using a different role completely, not just a different account
- using RBE service prod's role as default
