### PR TITLE
Remove provider definition

### DIFF
--- a/aws/providers.tf
+++ b/aws/providers.tf
@@ -1,3 +1,0 @@
-provider "aws" {
-  region = var.region
-}


### PR DESCRIPTION
This PR removes the `aws` provider definition entirely. Submodules are generally not recommended to define providers, only versions, because it conflicts with using this as anything other than a root module.